### PR TITLE
Added Cooling and Warming effects descriptions [1.19]

### DIFF
--- a/src/main/resources/assets/environmentz/lang/en_us.json
+++ b/src/main/resources/assets/environmentz/lang/en_us.json
@@ -1,7 +1,10 @@
 {
   "effect.environmentz.warming": "Warming",
   "effect.environmentz.cooling": "Cooling",
-  
+
+  "effect.environmentz.cooling.description": "Reduces body temperature, helping the user stay cool in hot environments.",
+  "effect.environmentz.warming.description": "Increases body temperature, keeping the user warm in cold environments.",
+
   "death.attack.freezing": "%1$s froze to death",
 
   "text.autoconfig.environmentz.title": "EnvironmentZ Config",


### PR DESCRIPTION
I propose to add effect descriptions for your mod.

With [Stylish Effects](https://www.curseforge.com/minecraft/mc-mods/stylish-effects), the descriptions render like this:
<img src="https://github.com/user-attachments/assets/2213a31e-4f70-40bc-a5e6-3dbb0345650c">

With [JEED](https://www.curseforge.com/minecraft/mc-mods/just-enough-effect-descriptions-jeed) installed, it looks like this:
<img src="https://github.com/user-attachments/assets/ead884aa-bb11-45c6-932d-0a21407b146e" height="300"><img src="https://github.com/user-attachments/assets/9f284c12-9b54-46d3-a21e-77e22d46e4ea" height="300">

I noticed the additional Comforts effect in 1.20, Coldness, Overheating, and Wet in 1.18/1.17. I play Minecraft 1.19. Therefore, I am not familiar with these effects, but we could also add the corresponding descriptions.